### PR TITLE
Ensure cart hidden prices update and recalc on sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,6 +356,19 @@
       const priceNode = textPriceNodes(item)[0];
       if (priceNode && priceNode.textContent.trim() !== fmt(val)){
         priceNode.textContent = fmt(val);
+
+        const priceTargets = [priceNode, item, ...item.querySelectorAll('input[type="hidden"], [data-price], [data-item-price], [data-price-each]')];
+        priceTargets.forEach(el => {
+          if ('value' in el) el.value = val;
+          if (el.dataset) {
+            Object.keys(el.dataset).forEach(k => {
+              if (/price/i.test(k)) el.dataset[k] = val;
+            });
+          }
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
         changed++;
       }
     }


### PR DESCRIPTION
## Summary
- Extend cart sync to update hidden price inputs and related data attributes
- Dispatch input/change events so cart totals recalc automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c10f606883318467b2b074f2899c