### PR TITLE
Ensure option values carry numeric prices

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,13 +140,15 @@
     if (!nameEl || !priceEl) return false;
 
     const sel = findSelect(card);
-    const label = sel?.options?.[sel.selectedIndex]?.textContent || '9+ months until expiration';
+    const opt = sel?.options?.[sel.selectedIndex];
+    const label = opt?.textContent || '9+ months until expiration';
 
     const row = resolveRow((nameEl.textContent||'').trim());
     if (!row) return false;
 
     const col = pickCol(label);
-    const val = row[col] ?? row.p9;
+    let val = Number(opt?.value);
+    if (!Number.isFinite(val)) val = row[col] ?? row.p9;
     if (val == null) return false;
 
     // prevent redundant writes
@@ -312,7 +314,11 @@
       const base = stripTrailingPrice(opt.textContent);
       const col  = pickCol(base);
       const val  = row[col] ?? row.p9;
-      if (val != null) opt.textContent = `${base} - ${fmt(val)}`;
+      if (val != null) {
+        opt.textContent   = `${base} - ${fmt(val)}`;
+        opt.value         = val;
+        opt.dataset.price = val;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add numeric values and data-price attributes to product card options
- parse option values as numbers when applying card prices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c10cd3a883318402ad02b5b3d3bc